### PR TITLE
MANIFEST.in: Add tests and docs to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,11 @@ include LICENSE
 include *.md
 include setup.py
 include MANIFEST.in
+include requirements.txt
 recursive-include django_core *
-recursive-exclude tests * 
+recursive-include tests *.py
+recursive-include docs *
+prune docs/_build
+include tests/requirements.txt
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     maintainer='Troy Grosfield',
     url='https://github.com/infoagetech/django-core',
     license='MIT',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     zip_safe=False,
     setup_requires=[


### PR DESCRIPTION
Also add exclusion in setup() to prevent tests in sdist
from being an installed package.

Closes https://github.com/InfoAgeTech/django-core/issues/4